### PR TITLE
Add $__fish_data_dir check for Fish 3.0

### DIFF
--- a/functions/man.fish
+++ b/functions/man.fish
@@ -22,7 +22,16 @@ function man --wraps man --description 'Format and display manual pages'
         type -q manpath
         and set MANPATH (command manpath)
     end
-    set -l fish_manpath (dirname $__fish_datadir)/fish/man
+
+    # Check data dir for Fish 2.x compatibility
+    set -l fish_data_dir
+    if set -q __fish_data_dir
+        set fish_data_dir $__fish_data_dir
+    else
+        set fish_data_dir $__fish_datadir
+    end
+
+    set -l fish_manpath (dirname $fish_data_dir)/fish/man
     if test -d "$fish_manpath" -a -n "$MANPATH"
         set MANPATH "$fish_manpath":$MANPATH
         command man $argv


### PR DESCRIPTION
Fish 3.0 uses `$__fish_data_dir` instead of `$__fish_datadir`. This was causing an error with the `dirname` command every time `man` was called on the latest Fish builds. Because of this, no Fish manpages were accessible.

This change checks for `$__fish_data_dir` and falls back to `$__fish_datadir` if it doesn't find it. One of those two variables should be defined.