### PR TITLE
Remove unnecessary `dirname` call

### DIFF
--- a/functions/man.fish
+++ b/functions/man.fish
@@ -23,15 +23,7 @@ function man --wraps man --description 'Format and display manual pages'
         and set MANPATH (command manpath)
     end
 
-    # Check data dir for Fish 2.x compatibility
-    set -l fish_data_dir
-    if set -q __fish_data_dir
-        set fish_data_dir $__fish_data_dir
-    else
-        set fish_data_dir $__fish_datadir
-    end
-
-    set -l fish_manpath (dirname $fish_data_dir)/fish/man
+    set -l fish_manpath $__fish_data_dir/man
     if test -d "$fish_manpath" -a -n "$MANPATH"
         set MANPATH "$fish_manpath":$MANPATH
         command man $argv


### PR DESCRIPTION
See https://github.com/fish-shell/fish-shell/commit/2cfb4343ed49aa976c8f6e5fc999198c0d873ef7#diff-e2c1373c8715bec537d5247400fe5f8de23eceaa2a1d79b61e90aaaf919c5aaa

I also took the chance to remove compatibility for Fish 2.x since [Fish 3.0](https://fishshell.com/docs/current/relnotes.html#fish-3-0-0-released-december-28-2018) is released more than 2.5 years ago and there's no reason not to upgrade.